### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,42 +6,42 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-RFD77402 KEYWORD1
+RFD77402	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin					KEYWORD2
+begin	KEYWORD2
 
-takeMeasurement			KEYWORD2
-getDistance				KEYWORD2
-getValidPixels			KEYWORD2
-getConfidenceValue		KEYWORD2
-getMode					KEYWORD2
+takeMeasurement	KEYWORD2
+getDistance	KEYWORD2
+getValidPixels	KEYWORD2
+getConfidenceValue	KEYWORD2
+getMode	KEYWORD2
 
-goToStandbyMode			KEYWORD2
-goToOffMode				KEYWORD2
-goToOnMode				KEYWORD2
-goToMeasurementMode		KEYWORD2
+goToStandbyMode	KEYWORD2
+goToOffMode	KEYWORD2
+goToOnMode	KEYWORD2
+goToMeasurementMode	KEYWORD2
 	
-getPeak					KEYWORD2
-setPeak					KEYWORD2
-getThreshold			KEYWORD2
-setThreshold			KEYWORD2
-getFrequency			KEYWORD2
-setFrequency			KEYWORD2
+getPeak	KEYWORD2
+setPeak	KEYWORD2
+getThreshold	KEYWORD2
+setThreshold	KEYWORD2
+getFrequency	KEYWORD2
+setFrequency	KEYWORD2
 
-getMailbox				KEYWORD2
-reset					KEYWORD2
-getChipID				KEYWORD2
+getMailbox	KEYWORD2
+reset	KEYWORD2
+getChipID	KEYWORD2
 
-getCalibrationData		KEYWORD2
+getCalibrationData	KEYWORD2
 
-readRegister16			KEYWORD2
-readRegister			KEYWORD2
-writeRegister16			KEYWORD2
-writeRegister			KEYWORD2
+readRegister16	KEYWORD2
+readRegister	KEYWORD2
+writeRegister16	KEYWORD2
+writeRegister	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords